### PR TITLE
feat: add performance monitoring and debug levels

### DIFF
--- a/docs/09_performance.md
+++ b/docs/09_performance.md
@@ -1,0 +1,224 @@
+# Performance Monitoring
+
+`mancha` includes built-in performance monitoring tools to help you identify and optimize slow renders. These tools are designed to have minimal overhead when disabled and provide detailed insights when enabled.
+
+## Debug Levels
+
+Performance monitoring is controlled through debug levels. The `debug()` method accepts either a boolean (for backwards compatibility) or a debug level string:
+
+```js
+const { $ } = Mancha;
+
+// Enable lifecycle-level debugging (recommended for most use cases)
+$.debug(true);        // Same as $.debug('lifecycle')
+$.debug('lifecycle');
+
+// Enable effect-level debugging (logs individual effect timings)
+$.debug('effects');
+
+// Enable verbose debugging (logs everything, including internal operations)
+$.debug('verbose');
+
+// Disable debugging
+$.debug(false);       // Same as $.debug('off')
+$.debug('off');
+```
+
+### Debug Level Behavior
+
+| Level      | Tracking                    | Console Output                           |
+|------------|-----------------------------|-----------------------------------------|
+| `off`      | Nothing                     | None                                    |
+| `lifecycle`| Lifecycle + effect stats    | Slow effects only (>16ms)               |
+| `effects`  | Same as lifecycle           | Above + individual effect timings       |
+| `verbose`  | Same as lifecycle           | Above + all internal logging            |
+
+The `lifecycle` level is the recommended default for performance analysis. It tracks all the data needed for `performanceReport()` while keeping console output minimal.
+
+## Performance Reports
+
+After mounting your application with debugging enabled, you can retrieve a structured performance report:
+
+```js
+const { $ } = Mancha;
+$.debug('lifecycle');
+await $.mount(document.body);
+
+const report = $.performanceReport();
+console.log(report);
+```
+
+### Report Structure
+
+```js
+{
+  lifecycle: {
+    mountTime: 45.2,        // Total mount time in milliseconds
+    preprocessTime: 12.1,   // Time spent in preprocessing phase
+    renderTime: 33.1        // Time spent in rendering phase
+  },
+  effects: {
+    total: 25,              // Total number of unique effects
+    byDirective: {
+      'bind': { count: 10, totalTime: 5.2 },
+      'for': { count: 3, totalTime: 15.8 },
+      'text': { count: 12, totalTime: 2.1 }
+    },
+    slowest: [              // Top 10 slowest effects
+      {
+        id: 'for:product-list:products',
+        executionCount: 1,
+        totalTime: 15.8,
+        avgTime: 15.8
+      },
+      // ...
+    ]
+  },
+  observers: {
+    totalKeys: 8,           // Number of unique keys being watched
+    totalObservers: 25,     // Total number of observers
+    byKey: {                // Observers per key
+      'products': 5,
+      'selectedItem': 3
+    }
+  }
+}
+```
+
+## Effect Identification
+
+Each effect is identified by a unique ID composed of the directive name, element identifier, and expression. The element identifier is determined by the following priority:
+
+1. `data-perfid` - Explicit performance ID (highest priority)
+2. `id` - Standard HTML id attribute
+3. `data-testid` - Common testing identifier
+4. Node path - Fallback, e.g., `html>body>div>ul>li:nth-child(2)`
+
+### Using data-perfid
+
+For reliable performance tracking, add `data-perfid` attributes to elements you want to monitor:
+
+```html
+<ul data-perfid="product-list" :for="product in products">
+  <li data-perfid="product-item">{{ product.name }}</li>
+</ul>
+
+<input data-perfid="search-input" :bind="searchQuery" />
+```
+
+This produces effect IDs like:
+- `for:product-list:products`
+- `bind:search-input:searchQuery`
+
+Without explicit identifiers, `mancha` falls back to the node path:
+- `for:html>body>main>ul:products`
+
+## Slow Effect Warnings
+
+When debugging is enabled at the `lifecycle` level or higher, `mancha` automatically logs warnings for effects that take longer than 16ms (the frame budget for 60fps):
+
+```
+Slow effect (23.5ms): for:product-list:items
+```
+
+This helps identify render bottlenecks without needing to analyze the full performance report.
+
+## Best Practices
+
+### 1. Profile Before Optimizing
+
+Always measure before making changes. Enable debugging, interact with your application, then check `performanceReport()`:
+
+```js
+$.debug('lifecycle');
+await $.mount(document.body);
+
+// Interact with your application...
+
+console.table($.performanceReport().effects.slowest);
+```
+
+### 2. Add data-perfid to Critical Elements
+
+For elements in loops or those with complex expressions, add `data-perfid` for clearer reports:
+
+```html
+<!-- Without data-perfid, the ID might be: for:html>body>div:nth-child(2)>ul:items -->
+<!-- With data-perfid, the ID is: for:order-list:items -->
+<ul data-perfid="order-list" :for="order in orders">
+  <li data-perfid="order-row">{{ order.id }}</li>
+</ul>
+```
+
+### 3. Check Observer Counts
+
+High observer counts on a single key can indicate performance issues:
+
+```js
+const report = $.performanceReport();
+for (const [key, count] of Object.entries(report.observers.byKey)) {
+  if (count > 50) {
+    console.warn(`Key "${key}" has ${count} observers - consider restructuring`);
+  }
+}
+```
+
+### 4. Reset on Each Mount
+
+Performance data automatically resets when `mount()` is called. This means each mount cycle gives you fresh timing data:
+
+```js
+$.debug('lifecycle');
+
+await $.mount(element1);
+console.log($.performanceReport()); // Data for element1
+
+await $.mount(element2);
+console.log($.performanceReport()); // Fresh data for element2 only
+```
+
+### 5. Disable in Production
+
+Performance tracking adds overhead. Always disable debugging in production:
+
+```js
+if (process.env.NODE_ENV !== 'production') {
+  $.debug('lifecycle');
+}
+```
+
+## Example: Identifying a Performance Issue
+
+```html
+<body :data="{ items: generateLargeList() }">
+  <div data-perfid="item-container" :for="item in items">
+    <span :text="expensiveFormat(item)"></span>
+  </div>
+</body>
+<script type="module">
+  import { Mancha } from 'mancha';
+
+  Mancha.debug('lifecycle');
+  await Mancha.mount(document.body);
+
+  const report = Mancha.performanceReport();
+
+  // Check which directives are slowest
+  console.log('By directive:', report.effects.byDirective);
+
+  // Check the 10 slowest individual effects
+  console.table(report.effects.slowest);
+</script>
+```
+
+Output might reveal:
+```js
+{
+  byDirective: {
+    'for': { count: 1, totalTime: 5.2 },
+    ':text': { count: 1000, totalTime: 450.8 }  // Problem!
+  }
+}
+```
+
+This shows that while `:for` is fast, the 1000 `:text` effects using `expensiveFormat()` are the bottleneck.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,3 +24,56 @@ export type RendererPlugin = (
 	node: ChildNode,
 	params?: RenderParams,
 ) => void | Promise<void>;
+
+/** Debug level for controlling performance tracking and logging verbosity. */
+export type DebugLevel = "off" | "lifecycle" | "effects" | "verbose";
+
+/** Metadata for identifying effects in performance tracking. */
+export type EffectMeta = {
+	/** The directive that created this effect (e.g., 'class', 'bind', 'for'). */
+	directive: string;
+	/** The DOM element associated with this effect, if any. */
+	element?: Element;
+	/** The expression being evaluated by this effect. */
+	expression?: string;
+};
+
+/** Statistics for a tracked effect. */
+export type EffectStats = {
+	/** Effect identifier (e.g., "bind:my-input:user.name"). */
+	id: string;
+	/** Number of times this effect has executed. */
+	executionCount: number;
+	/** Total execution time in milliseconds. */
+	totalTime: number;
+	/** Average execution time per invocation in milliseconds. */
+	avgTime: number;
+};
+
+/** Structured performance report returned by getPerformanceReport(). */
+export type PerformanceReport = {
+	/** Timing data for lifecycle methods. */
+	lifecycle: {
+		mountTime?: number;
+		preprocessTime?: number;
+		renderTime?: number;
+	};
+	/** Effect execution statistics. */
+	effects: {
+		/** Total number of unique effects tracked. */
+		total: number;
+		/** Aggregate stats grouped by directive type. */
+		byDirective: Record<string, { count: number; totalTime: number }>;
+		/** Top 10 slowest effects by total time. */
+		slowest: EffectStats[];
+	};
+	/** Observer registration statistics. */
+	observers: {
+		/** Number of keys with registered observers. */
+		totalKeys: number;
+		/** Total number of observer registrations. */
+		totalObservers: number;
+		/** Observer count per key. */
+		byKey: Record<string, number>;
+	};
+};

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -146,4 +146,167 @@ export function testSuite(ctor: new (data?: StoreState) => IRenderer): void {
 			assert.equal(result, 1);
 		});
 	});
+
+	describe("debug", () => {
+		it("accepts boolean true for backwards compatibility", () => {
+			const renderer = new ctor();
+			renderer.debug(true);
+			assert.equal(renderer.debugging, true);
+		});
+
+		it("accepts boolean false for backwards compatibility", () => {
+			const renderer = new ctor();
+			renderer.debug(true);
+			renderer.debug(false);
+			assert.equal(renderer.debugging, false);
+		});
+
+		it("accepts 'lifecycle' debug level", () => {
+			const renderer = new ctor();
+			renderer.debug("lifecycle");
+			assert.equal(renderer.debugging, true);
+		});
+
+		it("accepts 'effects' debug level", () => {
+			const renderer = new ctor();
+			renderer.debug("effects");
+			assert.equal(renderer.debugging, true);
+		});
+
+		it("accepts 'verbose' debug level", () => {
+			const renderer = new ctor();
+			renderer.debug("verbose");
+			assert.equal(renderer.debugging, true);
+		});
+
+		it("accepts 'off' debug level", () => {
+			const renderer = new ctor();
+			renderer.debug("off");
+			assert.equal(renderer.debugging, false);
+		});
+	});
+
+	describe("performanceReport", () => {
+		it("returns a performance report with lifecycle timing", async () => {
+			const renderer = new ctor();
+			renderer.debug(true);
+			const html = "<div>test</div>";
+			const fragment = renderer.parseHTML(html);
+			await renderer.mount(fragment);
+
+			const report = renderer.performanceReport();
+			assert.ok(report.lifecycle);
+			assert.ok(report.lifecycle.mountTime !== undefined, "mountTime should be defined");
+			assert.ok((report.lifecycle.mountTime as number) >= 0, "mountTime should be >= 0");
+		});
+
+		it("returns a performance report with effect stats", async () => {
+			const renderer = new ctor({ value: "hello" });
+			renderer.debug(true);
+			const html = '<div :text="value"></div>';
+			const fragment = renderer.parseHTML(html);
+			await renderer.mount(fragment);
+
+			const report = renderer.performanceReport();
+			assert.ok(report.effects);
+			assert.ok(typeof report.effects.total === "number");
+			assert.ok(report.effects.total >= 0);
+		});
+
+		it("returns a performance report with observer stats", async () => {
+			const renderer = new ctor({ value: "hello" });
+			renderer.debug(true);
+			const html = '<div :text="value"></div>';
+			const fragment = renderer.parseHTML(html);
+			await renderer.mount(fragment);
+
+			const report = renderer.performanceReport();
+			assert.ok(report.observers);
+			assert.ok(typeof report.observers.totalKeys === "number");
+			assert.ok(typeof report.observers.totalObservers === "number");
+		});
+
+		it("resets performance data on each mount", async () => {
+			const renderer = new ctor({ value: "hello" });
+			renderer.debug(true);
+			const html1 = '<div :text="value"></div>';
+			const fragment1 = renderer.parseHTML(html1);
+			await renderer.mount(fragment1);
+
+			const report1 = renderer.performanceReport();
+			const _mountTime1 = report1.lifecycle.mountTime;
+
+			const html2 = "<span>simple</span>";
+			const fragment2 = renderer.parseHTML(html2);
+			await renderer.mount(fragment2);
+
+			const report2 = renderer.performanceReport();
+			// Second mount should have reset the data, so mountTime should be different.
+			assert.ok(typeof report2.lifecycle.mountTime === "number");
+			// The second mount is simpler, but we can't guarantee it's faster, so just check it exists.
+			assert.ok(report2.lifecycle.mountTime !== undefined);
+		});
+	});
+
+	describe("buildEffectId", () => {
+		it("builds effect id from directive and expression", () => {
+			const renderer = new ctor();
+			const id = renderer.buildEffectId({
+				directive: "bind",
+				expression: "user.name",
+			});
+			assert.ok(id.includes("bind"));
+			assert.ok(id.includes("user.name"));
+		});
+
+		it("returns a valid effect id format", () => {
+			const renderer = new ctor();
+			const html = "<input />";
+			const fragment = renderer.parseHTML(html) as DocumentFragment;
+			const elem = fragment.querySelector("input") as HTMLElement;
+
+			const id = renderer.buildEffectId({
+				directive: "bind",
+				element: elem,
+				expression: "value",
+			});
+			// ID should have format "directive:elemId:expression".
+			const parts = id.split(":");
+			assert.ok(parts.length >= 2, "Effect ID should have at least directive and element parts");
+			assert.equal(parts[0], "bind");
+		});
+
+		it("includes element identifier in effect id", () => {
+			const renderer = new ctor();
+			const html = '<input id="test-input" />';
+			const fragment = renderer.parseHTML(html) as DocumentFragment;
+			const elem = fragment.querySelector("input") as HTMLElement;
+
+			const id = renderer.buildEffectId({
+				directive: "bind",
+				element: elem,
+				expression: "value",
+			});
+			// The ID should include some element identifier (id, testid, or path).
+			// Different DOM implementations may handle this differently.
+			assert.ok(id.startsWith("bind:"), "Effect ID should start with directive");
+			assert.ok(id.includes("value"), "Effect ID should include expression");
+		});
+
+		it("handles elements without id attributes", () => {
+			const renderer = new ctor();
+			const html = "<div><span><input /></span></div>";
+			const fragment = renderer.parseHTML(html) as DocumentFragment;
+			const elem = fragment.querySelector("input") as HTMLElement;
+
+			const id = renderer.buildEffectId({
+				directive: "bind",
+				element: elem,
+				expression: "value",
+			});
+			// Should still produce a valid ID with tag name from the path.
+			assert.ok(id.startsWith("bind:"), "Effect ID should start with directive");
+			assert.ok(id.length > 10, "Effect ID should have meaningful content");
+		});
+	});
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,5 @@
 import * as expressions from "./expressions/index.js";
+import type { EffectMeta } from "./interfaces.js";
 
 /**
  * Internal store properties that are always present. These are managed by the framework
@@ -259,7 +260,27 @@ export class SignalStore<T extends StoreState = StoreState> extends IDebouncer {
 		return this._store.has(key);
 	}
 
-	effect<T>(observer: Observer<T>): T {
+	/**
+	 * Returns observer statistics for performance reporting.
+	 */
+	getObserverStats(): { totalKeys: number; totalObservers: number; byKey: Record<string, number> } {
+		const byKey: Record<string, number> = {};
+		let totalObservers = 0;
+
+		for (const [key, observers] of this.observers) {
+			byKey[key] = observers.size;
+			totalObservers += observers.size;
+		}
+
+		return {
+			totalKeys: this.observers.size,
+			totalObservers,
+			byKey,
+		};
+	}
+
+	effect<T>(observer: Observer<T>, _meta?: EffectMeta): T {
+		// Base implementation ignores metadata; IRenderer overrides to add performance tracking.
 		return observer.call(this.proxify(observer));
 	}
 

--- a/src/trusted_attributes.ts
+++ b/src/trusted_attributes.ts
@@ -31,6 +31,6 @@ const colonToData = (attr: string) => `data-${attr.slice(1).replace(":", "-")}`;
 
 export const TRUSTED_DATA_ATTRIBS = TRUSTED_ATTRIBS.map((attr) => colonToData(attr));
 
-export const ADDITIONAL_DATA_ATTRIBS = ["data-testid"];
+export const ADDITIONAL_DATA_ATTRIBS = ["data-testid", "data-perfid"];
 
 export const SAFE_DATA_ATTRIBS = [...TRUSTED_DATA_ATTRIBS, ...ADDITIONAL_DATA_ATTRIBS];


### PR DESCRIPTION
## Summary
- Add debug levels ('off', 'lifecycle', 'effects', 'verbose') with backwards compatibility for `debug(true)`
- Track lifecycle timing (mount, preprocess, render phases)
- Track effect execution times with meaningful identifiers
- Log slow effects (>16ms threshold) automatically
- Add `performanceReport()` method for structured performance analysis
- Effect ID priority: `data-perfid` > `id` > `data-testid` > node path
- Add `data-perfid` to safe attributes list
- Add documentation in `docs/09_performance.md`

## Test plan
- [x] Existing tests pass (678 tests)
- [x] New tests for debug levels, performanceReport(), and buildEffectId()
- [x] Backwards compatibility: `debug(true)` maps to 'lifecycle' level

🤖 Generated with [Claude Code](https://claude.ai/code)