### PR TITLE
fix: enable deep reactivity for nested object property changes (#22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mancha",
-	"version": "0.20.4",
+	"version": "0.20.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mancha",
-			"version": "0.20.4",
+			"version": "0.20.5",
 			"license": "MIT",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mancha",
-	"version": "0.20.4",
+	"version": "0.20.5",
 	"description": "Javscript HTML rendering engine",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
## Summary

- Fixes #22: Nested property changes now trigger reactivity in `:for` subrenderers
- Lazily wrap nested objects on `get` access for deep reactivity
- Use blocklist instead of allowlist to support user-defined class instances
- Bump version to 0.20.5

## Test plan

- [x] Added test for nested object property reactivity in store
- [x] Added test for class instance property reactivity (including method calls)
- [x] Added test for `:for` + `:if` with nested property changes
- [x] All 778 tests pass
- [x] Linter and formatter clean