### PR TITLE
docs: add performance docs link and document deep reactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Here's a small sample of the things that you can do with `mancha`:
 - **[Server-Side Rendering](./docs/06_ssr.md)**: Using Mancha on the server (Node, Workers).
 - **[TypeScript](./docs/07_typescript.md)**: Type safety and checking.
 - **[Testing](./docs/08_testing.md)**: Testing your UI.
+- **[Performance](./docs/09_performance.md)**: Performance monitoring and optimization.
 
 ## AI Agents
 

--- a/docs/03_reactivity.md
+++ b/docs/03_reactivity.md
@@ -126,6 +126,43 @@ $.items = [];
 $.items.length = 0;   // No observer triggered - already empty
 ```
 
+### Deep Reactivity
+
+`mancha` supports deep reactivity for nested objects within arrays. When you modify a property of an object inside an array, observers are triggered automatically:
+
+```js
+$.items = [
+	{ name: "a", visible: false },
+	{ name: "b", visible: true },
+];
+
+// Modifying nested properties triggers observers
+$.items[0].visible = true;  // Observers triggered
+$.items[1].name = "c";      // Observers triggered
+```
+
+This also works with user-defined class instances:
+
+```js
+class Item {
+	constructor(name, visible) {
+		this.name = name;
+		this.visible = visible;
+	}
+	toggle() {
+		this.visible = !this.visible;
+	}
+}
+
+$.items = [new Item("a", false), new Item("b", true)];
+
+// Property changes trigger observers
+$.items[0].visible = true;  // Observers triggered
+
+// Class methods work and trigger reactivity
+$.items[0].toggle();        // Observers triggered
+```
+
 ### Replacing vs. Mutating
 
 When you assign a new array or object, observers always trigger because the reference changes:


### PR DESCRIPTION
## Summary
- Add missing reference to `09_performance.md` in README documentation section
- Document deep reactivity for nested object properties within arrays
- Document class instance support in the reactivity system

These documentation updates reflect the behavior changes introduced in #24.

## Test plan
- [x] Linter passes
- [x] All 898 tests pass