### PR TITLE
fix: handle frozen/sealed objects in deep reactivity (#26)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -182,6 +182,10 @@ export class SignalStore<T extends StoreState = StoreState> extends IDebouncer {
 		// Skip nulls and already-proxified objects.
 		if (obj == null || isProxified(obj)) return obj;
 
+		// Skip frozen/sealed objects - they can't be modified and proxying them would
+		// violate JS invariants (get trap must return actual value for non-configurable props).
+		if (Object.isFrozen(obj) || Object.isSealed(obj)) return obj;
+
 		// Skip built-in types that don't work well with proxies (have internal slots).
 		// User-defined class instances are allowed since their properties are just data.
 		if (


### PR DESCRIPTION
## Summary

- Fix TypeError when accessing properties of frozen/sealed objects in reactive context
- Skip frozen/sealed objects in `wrapObject` to prevent proxy invariant violations
- Add comprehensive tests for frozen arrays, sealed objects, and performance scenarios

## Problem

When objects are frozen or sealed using `Object.freeze()` or `Object.seal()`, the lazy wrapping code introduced in 0.20.5 would try to return a wrapped proxy for properties. This violates JavaScript's proxy invariants - the `get` trap must return the actual value for non-configurable properties, causing:

```
TypeError: 'get' on proxy: property 'X' is a read-only and non-configurable data property 
on the proxy target but the proxy did not return its actual value
```

## Solution

Add a check in `wrapObject` to skip frozen and sealed objects:

```typescript
if (Object.isFrozen(obj) || Object.isSealed(obj)) return obj;
```

## Test plan

- [x] Added test: `handles frozen arrays without errors`
- [x] Added test: `handles sealed objects without errors`
- [x] Added test: `accessing 64 items with nested properties completes in reasonable time`
- [x] Added test: `does not trigger spurious notifications when reading nested object properties`
- [x] All 783 tests pass
- [x] Linter passes

Fixes #26