### PR TITLE
fix: debounce notifications per key to prevent performance issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mancha",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mancha",
-			"version": "0.20.6",
+			"version": "0.20.7",
 			"license": "MIT",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mancha",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"description": "Javscript HTML rendering engine",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
## Summary
- Fixes performance regression when class instances stored in reactive state have methods that modify internal state
- Each modification was triggering separate debounced notifications, causing OOM and UI freezes
- Now uses a single Map to track notification state per key, coalescing multiple notify() calls

## Changes
- Removed `IDebouncer` abstract class (no longer needed)
- Added `_notify` Map to track pending/executing notifications per key
- Simplified `notify()` to handle debouncing inline

## Test plan
- [x] Added tests for notification debouncing behavior
- [x] All 794 tests pass
- [x] Linter clean