### PR TITLE
fix: improve $computed typing for ergonomic property assignment

### DIFF
--- a/docs/03_reactivity.md
+++ b/docs/03_reactivity.md
@@ -275,7 +275,24 @@ $.set('doubled', $.$computed(($) => $.count * 2));
 $.set('doubled', $.$computed(function() {
 	return this.count * 2;
 }));
+
+// Direct property assignment (also works)
+$.doubled = $.$computed(($) => $.count * 2);
 ```
+
+#### TypeScript Note
+
+The `$computed` method is typed to return `R` (the computed value type) rather than a marker object. This enables ergonomic property assignment without type casts:
+
+```typescript
+interface State { count: number; doubled: number }
+const renderer = new Renderer<State>({ count: 2, doubled: 0 });
+
+// Works without 'as any' - $computed returns type 'number'
+renderer.$.doubled = renderer.$.$computed(($) => $.count * 2);
+```
+
+**Important:** At runtime, `$computed` returns a marker object that signals to the store to set up reactive tracking. The return value must be assigned to a store property - do not use it directly as a value.
 
 ## URL Query Parameter Binding
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mancha",
-	"version": "0.20.7",
+	"version": "0.20.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mancha",
-			"version": "0.20.7",
+			"version": "0.20.10",
 			"license": "MIT",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mancha",
-	"version": "0.20.9",
+	"version": "0.20.10",
 	"description": "Javscript HTML rendering engine",
 	"main": "dist/index.js",
 	"type": "module",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1949,10 +1949,10 @@ describe("SignalStore", () => {
 		});
 
 		it("works via proxy assignment", async () => {
-			// Use Record<string, unknown> to allow dynamic property assignment via proxy.
-			const store = new SignalStore<Record<string, unknown>>({ x: 3 });
+			// With $computed returning R, we can use proper typing for computed properties.
+			const store = new SignalStore<{ x: number; squared: number }>({ x: 3, squared: 0 });
 			store.$.squared = store.$computed(function () {
-				return (this.x as number) * (this.x as number);
+				return this.x * this.x;
 			});
 			await sleepForReactivity();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -388,18 +388,30 @@ export class SignalStore<T extends StoreState = StoreState> {
 	}
 
 	/**
-	 * Creates a computed value marker. When passed to set(), the function will be
-	 * evaluated in a reactive effect, and the result stored. When dependencies change,
-	 * the function re-evaluates and updates the stored value.
+	 * Creates a computed property that automatically updates when its dependencies change.
+	 * The function is evaluated in a reactive effect, and the result is stored. When any
+	 * reactive property accessed within the function changes, it re-evaluates and updates.
+	 *
+	 * **Important:** This method returns a marker object at runtime, but is typed as
+	 * returning `R` to enable ergonomic property assignment without type casts. The return
+	 * value must be assigned to a store property (via `set()` or `$.prop =`) - do not use
+	 * it directly as a value.
 	 *
 	 * @example
 	 * // Using function() to access reactive `this`:
 	 * store.set('double', store.$computed(function() { return this.count * 2 }));
+	 *
 	 * // Using arrow function with $ parameter (for templates):
 	 * store.set('double', store.$computed(($) => $.count * 2));
+	 *
+	 * // Direct property assignment (ergonomic typing):
+	 * store.$.doubled = store.$computed(($) => $.count * 2);
 	 */
-	$computed<R>(fn: ComputedFn<T, R>): ComputedMarker<R> {
-		return { [COMPUTED_MARKER]: true, fn: fn as ComputedFn<StoreState, R> };
+	$computed<R>(fn: ComputedFn<T, R>): R {
+		// Returns a marker object that signals to set() this is a computed property.
+		// The return type is R (not ComputedMarker<R>) to allow ergonomic assignment
+		// like `$.prop = $computed(fn)` without requiring type casts.
+		return { [COMPUTED_MARKER]: true, fn: fn as ComputedFn<StoreState, R> } as R;
 	}
 
 	private proxify<T>(observer?: Observer<T>): SignalStoreProxy {


### PR DESCRIPTION
## Summary
- Change `$computed` return type from `ComputedMarker<R>` to `R` to enable ergonomic property assignment
- Add documentation explaining the type design decision
- Update test to use proper typing instead of `Record<string, unknown>` workaround

## Problem
Previously, assigning a computed property required type casts:
```typescript
$.prop = $.$computed(() => ...) as any;
```

## Solution
The return type is now `R` (the computed value type) instead of `ComputedMarker<R>`. This enables:
```typescript
store.$.doubled = store.$computed(($) => $.count * 2);  // No cast needed
```

At runtime, a marker object is still returned and correctly handled by the store's set handler. The type change is a pragmatic trade-off documented in the code and docs.

## Test plan
- [x] All existing tests pass
- [x] Updated test now uses proper typing instead of `Record<string, unknown>`
- [x] Linter passes