### PR TITLE
fix: add effect metadata for computed properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mancha",
-	"version": "0.20.10",
+	"version": "0.20.11",
 	"description": "Javscript HTML rendering engine",
 	"main": "dist/index.js",
 	"type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,6 +36,8 @@ export type EffectMeta = {
 	element?: Element;
 	/** The expression being evaluated by this effect. */
 	expression?: string;
+	/** Direct identifier for effects without a DOM element (e.g., computed property key). */
+	id?: string;
 };
 
 /** Statistics for a tracked effect. */

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -154,11 +154,14 @@ export abstract class IRenderer<T extends StoreState = StoreState> extends Signa
 		const expression = ellipsize(meta?.expression ?? "", 32);
 		const elem = meta?.element as HTMLElement | undefined;
 
-		const elemId = elem
-			? (elem.dataset?.perfid ?? elem.id ?? elem.dataset?.testid ?? this.getNodePath(elem))
-			: "unknown";
+		// Use explicit id if provided (e.g., for computed properties without DOM elements).
+		const elemId =
+			meta?.id ??
+			(elem
+				? (elem.dataset?.perfid ?? elem.id ?? elem.dataset?.testid ?? this.getNodePath(elem))
+				: "unknown");
 
-		return `${directive}:${elemId}:${expression}`;
+		return expression ? `${directive}:${elemId}:${expression}` : `${directive}:${elemId}`;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Computed properties now include directive and key name in effect metadata
- Slow effect warnings show `computed:keyName` instead of `unknown:unknown`
- Added optional `id` field to `EffectMeta` for effects without DOM elements

## Test plan
- [x] Added unit test for `buildEffectId` with explicit `id` field
- [x] Added integration test verifying computed effects are tracked correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)