### PR TITLE
fix: handle non-string values in :text directive

### DIFF
--- a/src/plugins.test.ts
+++ b/src/plugins.test.ts
@@ -1820,6 +1820,111 @@ export function testSuite(ctor: new (data?: StoreState) => IRenderer): void {
 			assert.equal(renderer.get("foo"), "bar");
 			assert.equal(getTextContent(node), "bar");
 		});
+
+		it("render positive number", async () => {
+			const renderer = new ctor({ counter: 42 });
+			const html = `<div :text="counter"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "42");
+		});
+
+		it("render zero", async () => {
+			const renderer = new ctor({ counter: 0 });
+			const html = `<div :text="counter"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "0");
+		});
+
+		it("render negative number", async () => {
+			const renderer = new ctor({ value: -123 });
+			const html = `<div :text="value"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "-123");
+		});
+
+		it("render floating point number", async () => {
+			const renderer = new ctor({ value: 1.5 });
+			const html = `<div :text="value"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "1.5");
+		});
+
+		it("render boolean true", async () => {
+			const renderer = new ctor({ flag: true });
+			const html = `<div :text="flag"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "true");
+		});
+
+		it("render boolean false", async () => {
+			const renderer = new ctor({ flag: false });
+			const html = `<div :text="flag"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "false");
+		});
+
+		it("render null as empty string", async () => {
+			const renderer = new ctor({ value: null });
+			const html = `<div :text="value"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "");
+		});
+
+		it("render undefined as empty string", async () => {
+			const renderer = new ctor({ value: undefined });
+			const html = `<div :text="value"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "");
+		});
+
+		it("render empty string", async () => {
+			const renderer = new ctor({ value: "" });
+			const html = `<div :text="value"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "");
+		});
+
+		it("render expression result as number", async () => {
+			const renderer = new ctor({ a: 10, b: 5 });
+			const html = `<div :text="a + b"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "15");
+		});
+
+		it("updates reactively when number changes", async () => {
+			const renderer = new ctor({ counter: 1 });
+			const html = `<div :text="counter"></div>`;
+			const fragment = renderer.parseHTML(html);
+			const node = fragment.firstChild as HTMLElement;
+			await renderer.mount(fragment);
+			assert.equal(getTextContent(node), "1");
+
+			await renderer.set("counter", 2);
+			assert.equal(getTextContent(node), "2");
+
+			await renderer.set("counter", 0);
+			assert.equal(getTextContent(node), "0");
+		});
 	});
 
 	describe(":html", () => {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -211,8 +211,11 @@ export namespace RendererPlugins {
 			function (this: IRenderer) {
 				let updatedContent = content;
 				for (const expr of expressions) {
-					const result = this.eval(expr, { $elem: node }) as string;
-					updatedContent = updatedContent.replace(`{{ ${expr} }}`, String(result));
+					const result = this.eval(expr, { $elem: node });
+					updatedContent = updatedContent.replace(
+						`{{ ${expr} }}`,
+						result == null ? "" : String(result),
+					);
 				}
 				node.nodeValue = updatedContent;
 			},
@@ -322,7 +325,8 @@ export namespace RendererPlugins {
 			const setTextContent = (content: string) => this.textContent(node, content);
 			return this.effect(
 				function (this: IRenderer) {
-					setTextContent(this.eval(textAttr, { $elem: node }) as string);
+					const result = this.eval(textAttr, { $elem: node });
+					setTextContent(result == null ? "" : String(result));
 				},
 				{ directive: ":text", element: elem, expression: textAttr },
 			);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -25,7 +25,7 @@ export class Renderer extends IRenderer {
 		return new Comment(content) as unknown as Node;
 	}
 	textContent(node: Node, content: string): void {
-		(node as unknown as Element).children = [new Text(content)];
+		(node as unknown as Element).children = [new Text(String(content))];
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #41 - The `:text` directive was failing when the expression evaluated to a number in the Worker renderer.

**Issues fixed:**
- `TypeError: str.slice is not a function` when `:text` evaluates to a number like `42`
- Zero (`0`) rendering as empty instead of `"0"` due to falsy checks

**Changes:**
- Convert values to string in `resolveTextAttributes` using `String()`
- Treat `null`/`undefined` as empty string for cleaner output
- Add defensive `String()` conversion in worker.ts `textContent`
- Update `resolveTextNodeExpressions` for consistency with `:text`

## Test plan

- [x] Added 11 new tests for `:text` with various types
- [x] All 970 node tests passing
- [x] Linter clean

| Value | Renders as |
|-------|-----------|
| `42` | `"42"` |
| `0` | `"0"` |
| `false` | `"false"` |
| `null` | `""` |
| `undefined` | `""` |