### PR TITLE
docs: add :key attribute documentation

### DIFF
--- a/docs/01_syntax.md
+++ b/docs/01_syntax.md
@@ -13,6 +13,10 @@
   ```html
   <div :for="item in ['a', 'b', 'c']">{{ item }}</div>
   ```
+- `:key` (used with `:for`) enables keyed reconciliation, which reuses DOM nodes when items have stable identifiers. This prevents unnecessary DOM recreation and preserves element state during updates. The key should be a unique primitive value (string or number).
+  ```html
+  <div :for="user in users" :key="user.id">{{ user.name }}</div>
+  ```
 - `:text` sets the `textContent` value of a node
   ```html
   <div :data="{foo: 'bar'}" :text="foo"></div>

--- a/docs/03_reactivity.md
+++ b/docs/03_reactivity.md
@@ -310,6 +310,23 @@ For most use cases, you don't need to do anything—cleanup happens automaticall
 
 When items are removed from the array, the corresponding `<li>` elements are removed from the DOM, and their observers are cleaned up the next time any observer is notified.
 
+### Keyed Reconciliation and Observer Reuse
+
+When using `:key` with `:for`, subrenderers are reused for items with matching keys rather than being disposed and recreated. This is more efficient because existing observers remain attached:
+
+```html
+<ul :for="user in users" :key="user.id">
+	<li>{{ user.name }}</li>
+</ul>
+```
+
+With `:key`, when the `users` array is updated:
+- Items with the same key keep their subrenderer and observers
+- Only truly removed items have their observers cleaned up
+- New items create new subrenderers with fresh observers
+
+Without `:key`, every update disposes all subrenderers and creates new ones, which triggers more cleanup and setup cycles. See [Performance](./09_performance.md#4-use-key-for-list-performance) for more details.
+
 ### Manual Cleanup with dispose()
 
 For advanced use cases where you're managing renderers programmatically, you can explicitly dispose of a store to clear all its observers:

--- a/docs/09_performance.md
+++ b/docs/09_performance.md
@@ -185,7 +185,27 @@ for (const [key, count] of Object.entries(report.observers.byKey)) {
 }
 ```
 
-### 4. Reset on Each Mount
+### 4. Use `:key` for List Performance
+
+When rendering lists with `:for`, add the `:key` attribute to enable keyed reconciliation. This reuses existing DOM nodes when items are updated, reordered, or partially changed, instead of recreating all nodes:
+
+```html
+<!-- Without :key - all nodes recreated on every update -->
+<li :for="user in users">{{ user.name }}</li>
+
+<!-- With :key - nodes are reused based on stable identifier -->
+<li :for="user in users" :key="user.id">{{ user.name }}</li>
+```
+
+Benefits of keyed reconciliation:
+- **Faster updates**: Only changed items trigger DOM operations
+- **No visual flicker**: Existing elements stay in place
+- **Preserved state**: Form inputs, scroll position, and animations are maintained
+- **Efficient reordering**: Moving items doesn't require recreation
+
+The key should be a unique primitive value (string or number) that identifies each item. Avoid using array indices as keys if items can be reordered or inserted.
+
+### 5. Reset on Each Mount
 
 Performance data automatically resets when `mount()` is called. This means each mount cycle gives you fresh timing data:
 
@@ -199,7 +219,7 @@ await $.mount(element2);
 console.log($.getPerformanceReport()); // Fresh data for element2 only
 ```
 
-### 5. Disable in Production
+### 6. Disable in Production
 
 Performance tracking adds overhead. Always disable debugging in production:
 


### PR DESCRIPTION
## Summary
- Added `:key` attribute documentation to the syntax reference (01_syntax.md)
- Added "Keyed Reconciliation and Observer Reuse" section to reactivity guide (03_reactivity.md)
- Added "Use `:key` for List Performance" best practice to performance guide (09_performance.md)

This documents the keyed reconciliation feature added in #46.

## Test plan
- [x] Verify documentation renders correctly in markdown
- [x] Verify cross-links between documents work