### PR TITLE
fix: re-evaluate :data when keyed :for items are reused

### DIFF
--- a/docs/01_syntax.md
+++ b/docs/01_syntax.md
@@ -4,7 +4,7 @@
 
 ## Attributes
 
-- `:data` provides scoped variables to all subnodes, evaluated using `jexpr`. Use `$computed` for derived values that update automatically (see [Reactivity](./03_reactivity.md#computed-values)).
+- `:data` provides scoped variables to all subnodes, evaluated once at mount time. Use `$computed` for derived values that update automatically (see [Reactivity](./03_reactivity.md#computed-values)). Note: `:data` is re-evaluated when used with `:for` + `:key` and the keyed node is reused.
   ```html
   <div :data="{ name: 'Stranger' }"></div>
   <div :data="{ count: 1, doubled: $computed(() => count * 2) }"></div>
@@ -13,9 +13,11 @@
   ```html
   <div :for="item in ['a', 'b', 'c']">{{ item }}</div>
   ```
-- `:key` (used with `:for`) enables keyed reconciliation, which reuses DOM nodes when items have stable identifiers. This prevents unnecessary DOM recreation and preserves element state during updates. The key should be a unique primitive value (string or number).
+- `:key` (used with `:for`) enables keyed reconciliation, which reuses DOM nodes when items have stable identifiers. This prevents unnecessary DOM recreation and preserves element state during updates. The key should be a unique primitive value (string or number). When used with `:data`, the `:data` expression is re-evaluated when a keyed node is reused with updated loop variables.
   ```html
   <div :for="user in users" :key="user.id">{{ user.name }}</div>
+  <!-- :data bindings update when the item changes -->
+  <div :for="item in items" :key="item.id" :data="{ label: item.name }">{{ label }}</div>
   ```
 - `:text` sets the `textContent` value of a node
   ```html


### PR DESCRIPTION
## Summary

- Fixes issue where `:data` bindings become stale when `:for` with `:key` reuses a DOM node
- When a keyed node is reused with updated loop variables, the `:data` expression is now re-evaluated
- This makes keyed mode behave consistently with non-keyed mode for `:data` bindings

## Test plan

- [x] Added test for `:for` + `:key` + `:data` combination
- [x] Verified all existing tests pass
- [x] Updated documentation to clarify `:data` behavior with `:key`

🤖 Generated with [Claude Code](https://claude.ai/code)