### PR TITLE
docs: add custom to css bundle options in initialization guide

### DIFF
--- a/docs/02_initialization.md
+++ b/docs/02_initialization.md
@@ -67,7 +67,7 @@ The simplest way to use mancha is via a script tag with the `init` attribute:
 |-----------|-------------|---------|
 | `init` | Enables automatic initialization on page load | `init` |
 | `target` | CSS selector(s) to mount to (default: `body`). Use `+` to separate multiple targets | `target="main"` or `target="#app+#sidebar"` |
-| `css` | CSS bundles to inject. Use `+` to separate multiple | `css="utils"` or `css="basic+utils"` |
+| `css` | CSS bundles to inject (`minimal`, `basic`, `utils`, `custom`). Use `+` to separate multiple | `css="utils"` or `css="utils+custom"` |
 | `debug` | Enable debug logging | `debug` |
 | `cache` | Fetch cache policy for includes | `cache="no-cache"` |
 | `cloak` | Control FOUC prevention (see below) | `cloak="200"` or `cloak="false"` |

--- a/docs/05_css.md
+++ b/docs/05_css.md
@@ -511,6 +511,88 @@ You can also control the opacity of any color utility by appending `/{opacity}` 
 | `text-{0-99}px` | Font size in pixels (e.g., `text-12px`, `text-16px`) |
 | `text-{0-24.75}rem` | Font size in rem units (0.25rem increments) |
 
---- 
+---
+
+## Custom Values
+
+When you need a value outside the design scale, use bracket notation as an escape hatch.
+
+### Enabling Custom Values
+
+Add "custom" to your CSS injection:
+
+```html
+<script src="//unpkg.com/mancha" css="utils+custom" init></script>
+```
+
+Or programmatically:
+
+```javascript
+import { injectCss, initMancha } from "mancha";
+
+injectCss(["utils", "custom"]);
+await initMancha({ target: "body" });
+```
+
+### Syntax
+
+```html
+<div class="w-[133px] mt-[2rem] max-w-[900px]">
+```
+
+### Supported Properties
+
+| Prefix | CSS Property |
+|--------|--------------|
+| `w-` | width |
+| `h-` | height |
+| `min-w-`, `min-h-` | min-width, min-height |
+| `max-w-`, `max-h-` | max-width, max-height |
+| `m-`, `mt-`, `mr-`, `mb-`, `ml-` | margin |
+| `mx-`, `my-` | margin-inline, margin-block |
+| `p-`, `pt-`, `pr-`, `pb-`, `pl-` | padding |
+| `px-`, `py-` | padding-inline, padding-block |
+| `top`, `right`, `bottom`, `left` | positioning |
+| `gap-`, `gap-x-`, `gap-y-` | gap |
+| `text-` | font-size |
+| `z-` | z-index |
+| `bg-` | background-color |
+| `border-` | border-color |
+
+### Variants
+
+Custom values support pseudo-states and responsive breakpoints:
+
+```html
+<div class="hover:w-[200px] md:max-w-[900px]">
+```
+
+### Limitations
+
+**Static classes only**: Custom values work with the `class` attribute, not `:class`:
+
+```html
+<!-- ✓ Works -->
+<div class="w-[133px]">
+
+<!-- ✗ Not supported - use inline styles instead -->
+<div :class="'w-[133px]'">
+<div :attr:style="'width: ' + dynamicWidth">
+```
+
+**Browser only**: Custom values require the CSSStyleSheet API and are not available in Worker or SSR environments.
+
+### When to Use
+
+**Prefer the design scale** for consistency. Use custom values for:
+- Matching external constraints (third-party widgets, embeds)
+- One-off pixel-perfect adjustments
+- Rapid prototyping (replace with scale values later)
+
+### Dynamic Content
+
+For content added after initial load, call `injectCss(["custom"])` again to scan and inject new custom values.
+
+---
 
 *Generated automatically from `src/css_gen_utils.ts`*

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"build": "gulp build",
 		"pretest": "npm run build",
 		"test:node": "mocha 'dist/**/*.test.js' --ignore 'dist/browser.test.js'",
-		"test:browser": "web-test-runner 'dist/**/*.test.js' '!dist/cli.test.js' '!dist/ssr.test.js' '!dist/index.test.js' '!dist/worker.test.js' '!dist/type_checker.test.js' --node-resolve --compatibility all --playwright --browsers chromium --no-sandbox",
+		"test:browser": "web-test-runner 'dist/**/*.test.js' '!dist/cli.test.js' '!dist/ssr.test.js' '!dist/index.test.js' '!dist/worker.test.js' '!dist/type_checker.test.js' '!dist/css_custom.test.js' --node-resolve --compatibility all --playwright --browsers chromium --no-sandbox",
 		"test": "npm run test:node && npm run test:browser",
 		"check:size": "brotli -c dist/mancha.js | wc -c",
 		"cli": "node dist/cli.js",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,10 @@
 import { safeStyleEl } from "safevalues/dom";
+import { _resetForTesting as resetCustomCss, scanAndInject } from "./css_custom.js";
 import { dirname } from "./dome.js";
+
+// Re-export for testing.
+export { resetCustomCss as _resetCustomCssForTesting };
+
 import type { ParserParams, RenderParams } from "./interfaces.js";
 import { IRenderer } from "./renderer.js";
 import type { StoreState } from "./store.js";
@@ -53,14 +58,20 @@ export class Renderer<T extends StoreState = StoreState> extends IRenderer<T> {
 export const Mancha = new Renderer();
 
 /** Options for CSS injection. */
-export type CssName = "minimal" | "utils" | "basic";
+export type CssName = "minimal" | "utils" | "basic" | "custom";
 
 /**
  * Injects CSS rules into the document head.
- * @param names - Array of CSS names to inject ("minimal", "utils", "basic").
+ * @param names - Array of CSS names to inject ("minimal", "utils", "basic", "custom").
  */
 export function injectCss(names: CssName[]): void {
 	for (const styleName of names) {
+		if (styleName === "custom") {
+			// Scan DOM and inject custom value CSS (browser-only).
+			scanAndInject(document);
+			continue;
+		}
+
 		const style = document.createElement("style");
 		switch (styleName) {
 			case "minimal":

--- a/src/css_custom.test.ts
+++ b/src/css_custom.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, it } from "node:test";
+import {
+	_getInjectedRules,
+	_resetForTesting,
+	isSupported,
+	parseCustomValueClass,
+	processClassString,
+} from "./css_custom.js";
+import { assert } from "./test_utils.js";
+
+describe("css_custom", () => {
+	beforeEach(() => _resetForTesting());
+
+	describe("parseCustomValueClass", () => {
+		it("parses width", () => {
+			const result = parseCustomValueClass("w-[133px]");
+			assert.deepEqual(result, { property: "width", value: "133px" });
+		});
+
+		it("parses negative margin", () => {
+			const result = parseCustomValueClass("-mt-[2rem]");
+			assert.deepEqual(result, { property: "margin-top", value: "-2rem" });
+		});
+
+		it("parses max-width", () => {
+			const result = parseCustomValueClass("max-w-[900px]");
+			assert.deepEqual(result, { property: "max-width", value: "900px" });
+		});
+
+		it("parses background color", () => {
+			const result = parseCustomValueClass("bg-[#ff5733]");
+			assert.deepEqual(result, { property: "background-color", value: "#ff5733" });
+		});
+
+		it("parses rem values", () => {
+			const result = parseCustomValueClass("p-[2.5rem]");
+			assert.deepEqual(result, { property: "padding", value: "2.5rem" });
+		});
+
+		it("parses calc expressions", () => {
+			const result = parseCustomValueClass("w-[calc(100%-2rem)]");
+			assert.deepEqual(result, { property: "width", value: "calc(100%-2rem)" });
+		});
+
+		it("parses height", () => {
+			const result = parseCustomValueClass("h-[50vh]");
+			assert.deepEqual(result, { property: "height", value: "50vh" });
+		});
+
+		it("parses min-height", () => {
+			const result = parseCustomValueClass("min-h-[100px]");
+			assert.deepEqual(result, { property: "min-height", value: "100px" });
+		});
+
+		it("parses gap", () => {
+			const result = parseCustomValueClass("gap-[1.5rem]");
+			assert.deepEqual(result, { property: "gap", value: "1.5rem" });
+		});
+
+		it("parses gap-x", () => {
+			const result = parseCustomValueClass("gap-x-[10px]");
+			assert.deepEqual(result, { property: "column-gap", value: "10px" });
+		});
+
+		it("parses gap-y", () => {
+			const result = parseCustomValueClass("gap-y-[20px]");
+			assert.deepEqual(result, { property: "row-gap", value: "20px" });
+		});
+
+		it("parses z-index", () => {
+			const result = parseCustomValueClass("z-[9999]");
+			assert.deepEqual(result, { property: "z-index", value: "9999" });
+		});
+
+		it("parses font-size", () => {
+			const result = parseCustomValueClass("text-[14px]");
+			assert.deepEqual(result, { property: "font-size", value: "14px" });
+		});
+
+		it("parses border-color", () => {
+			const result = parseCustomValueClass("border-[#ccc]");
+			assert.deepEqual(result, { property: "border-color", value: "#ccc" });
+		});
+
+		it("parses margin-inline", () => {
+			const result = parseCustomValueClass("mx-[auto]");
+			assert.deepEqual(result, { property: "margin-inline", value: "auto" });
+		});
+
+		it("parses position properties", () => {
+			assert.deepEqual(parseCustomValueClass("top-[10px]"), { property: "top", value: "10px" });
+			assert.deepEqual(parseCustomValueClass("left-[50%]"), { property: "left", value: "50%" });
+		});
+
+		it("returns null for non-custom class", () => {
+			assert.equal(parseCustomValueClass("w-4"), null);
+		});
+
+		it("returns null for unknown prefix", () => {
+			assert.equal(parseCustomValueClass("foo-[bar]"), null);
+		});
+
+		it("returns null for empty brackets", () => {
+			assert.equal(parseCustomValueClass("w-[]"), null);
+		});
+	});
+
+	describe("processClassString", () => {
+		it("skips strings without brackets", () => {
+			processClassString("flex w-4 mt-8");
+			assert.equal(_getInjectedRules().size, 0);
+		});
+
+		it("skips empty strings", () => {
+			processClassString("");
+			assert.equal(_getInjectedRules().size, 0);
+		});
+
+		it("skips null-like values", () => {
+			processClassString(null as unknown as string);
+			assert.equal(_getInjectedRules().size, 0);
+		});
+	});
+
+	describe("isSupported", () => {
+		it("returns boolean", () => {
+			assert.equal(typeof isSupported(), "boolean");
+		});
+	});
+});

--- a/src/css_custom.ts
+++ b/src/css_custom.ts
@@ -1,0 +1,188 @@
+import { MEDIA_BREAKPOINTS } from "./css_gen_utils.js";
+
+// Property prefix to CSS property mapping.
+const PROPERTY_MAP: Record<string, string> = {
+	// Sizing.
+	w: "width",
+	h: "height",
+	"min-w": "min-width",
+	"min-h": "min-height",
+	"max-w": "max-width",
+	"max-h": "max-height",
+
+	// Spacing.
+	m: "margin",
+	mt: "margin-top",
+	mr: "margin-right",
+	mb: "margin-bottom",
+	ml: "margin-left",
+	mx: "margin-inline",
+	my: "margin-block",
+	p: "padding",
+	pt: "padding-top",
+	pr: "padding-right",
+	pb: "padding-bottom",
+	pl: "padding-left",
+	px: "padding-inline",
+	py: "padding-block",
+
+	// Position.
+	top: "top",
+	right: "right",
+	bottom: "bottom",
+	left: "left",
+
+	// Other.
+	gap: "gap",
+	"gap-x": "column-gap",
+	"gap-y": "row-gap",
+	text: "font-size",
+	z: "z-index",
+
+	// Colors.
+	bg: "background-color",
+	border: "border-color",
+};
+
+// Pattern: optional-negative + prefix + bracket-value.
+const CUSTOM_VALUE_PATTERN = /^(-?)([\w-]+)-\[(.+)\]$/;
+const VARIANT_PATTERN = /^(hover|focus|disabled|sm|md|lg|xl):(.+)$/;
+const PSEUDO_STATES = ["hover", "focus", "disabled"];
+
+// Module state.
+const injectedRules = new Set<string>();
+let styleSheet: CSSStyleSheet | null = null;
+
+/** Check if CSSStyleSheet API is available. */
+export function isSupported(): boolean {
+	return (
+		typeof document !== "undefined" &&
+		typeof CSSStyleSheet !== "undefined" &&
+		typeof document.createElement === "function"
+	);
+}
+
+/** Escape CSS selector special characters. */
+function escapeSelector(str: string): string {
+	return str.replace(/[[\]#.:>+~()'"]/g, "\\$&");
+}
+
+/** Get or create the stylesheet. */
+function getStyleSheet(): CSSStyleSheet | null {
+	if (!isSupported()) return null;
+	if (styleSheet) return styleSheet;
+
+	const style = document.createElement("style");
+	style.setAttribute("data-mancha", "custom");
+	document.head.appendChild(style);
+
+	// style.sheet may be null if the style element hasn't been attached to the DOM yet.
+	if (!style.sheet) return null;
+
+	styleSheet = style.sheet;
+	return styleSheet;
+}
+
+/** Parse a custom value class. */
+export function parseCustomValueClass(
+	className: string,
+): { property: string; value: string } | null {
+	const match = className.match(CUSTOM_VALUE_PATTERN);
+	if (!match) return null;
+
+	const [, negative, prefix, rawValue] = match;
+	const property = PROPERTY_MAP[prefix];
+	if (!property) return null;
+
+	const value = negative ? `-${rawValue}` : rawValue;
+	return { property, value };
+}
+
+/** Inject a single custom value class (with optional variant). */
+export function injectCustomClass(
+	className: string,
+	variant?: { type: "pseudo" | "media"; name: string },
+): boolean {
+	const fullClassName = variant ? `${variant.name}:${className}` : className;
+
+	// Already injected.
+	if (injectedRules.has(fullClassName)) return true;
+
+	const parsed = parseCustomValueClass(className);
+	if (!parsed) return false;
+
+	const sheet = getStyleSheet();
+	if (!sheet) return false;
+
+	const { property, value } = parsed;
+	const escapedClass = escapeSelector(fullClassName);
+
+	let rule: string;
+	if (!variant) {
+		rule = `.${escapedClass} { ${property}: ${value}; }`;
+	} else if (variant.type === "pseudo") {
+		rule = `.${escapedClass}:${variant.name} { ${property}: ${value}; }`;
+	} else {
+		const bp = MEDIA_BREAKPOINTS[variant.name as keyof typeof MEDIA_BREAKPOINTS];
+		rule = `@media (min-width: ${bp}px) { .${escapedClass} { ${property}: ${value}; } }`;
+	}
+
+	try {
+		sheet.insertRule(rule, sheet.cssRules.length);
+		injectedRules.add(fullClassName);
+		return true;
+	} catch (e) {
+		console.warn(`Failed to inject CSS rule: ${rule}`, e);
+		return false;
+	}
+}
+
+/** Process a class string, inject CSS for any custom values. */
+export function processClassString(classString: string): void {
+	if (!classString || !classString.includes("[")) return;
+
+	for (const cls of classString.trim().split(/\s+/)) {
+		// Check for variant prefix.
+		const variantMatch = cls.match(VARIANT_PATTERN);
+		if (variantMatch) {
+			const [, variantName, baseClass] = variantMatch;
+			const isPseudo = PSEUDO_STATES.includes(variantName);
+			const isMedia = variantName in MEDIA_BREAKPOINTS;
+			if (isPseudo || isMedia) {
+				injectCustomClass(baseClass, {
+					type: isPseudo ? "pseudo" : "media",
+					name: variantName,
+				});
+				continue;
+			}
+		}
+
+		// Try as base class.
+		injectCustomClass(cls);
+	}
+}
+
+/** Scan a DOM tree and inject CSS for all custom values found. */
+export function scanAndInject(root: Element | Document = document): void {
+	if (!isSupported()) return;
+
+	const elements = root.querySelectorAll("[class]");
+	for (const el of elements) {
+		const classAttr = el.getAttribute("class");
+		if (classAttr) processClassString(classAttr);
+	}
+}
+
+/** For testing: reset module state. */
+export function _resetForTesting(): void {
+	injectedRules.clear();
+	if (styleSheet?.ownerNode) {
+		(styleSheet.ownerNode as Element).remove();
+	}
+	styleSheet = null;
+}
+
+/** For testing: get injected rules. */
+export function _getInjectedRules(): Set<string> {
+	return injectedRules;
+}


### PR DESCRIPTION
Minor documentation fix to mention `custom` as an available CSS bundle option in the initialization guide's attribute table.