### PR TITLE
utils: add transition-property helpers (transition-all, transition-opacity, …)

### DIFF
--- a/docs/05_css.md
+++ b/docs/05_css.md
@@ -1,6 +1,6 @@
 # CSS Documentation
 
-Mancha provides two CSS modes: **minimal** for simple prose pages, and **utils** for Tailwind-style utility class development.
+Mancha provides a set of CSS utilities and minimal styles to help you build your application.
 
 ## Minimal CSS
 
@@ -13,6 +13,18 @@ The minimal CSS rules provide a clean, readable default style for standard HTML 
 - **Font Family**: sans-serif
 - **H1-H6 Margin**: 1em 0 0.5em
 - **P, UL, OL Margin Bottom**: 1em
+
+## Basic CSS
+
+The basic CSS rules provide a more comprehensive reset and set of defaults, widely based on Tailwind CSS Preflight. You can inject them using `injectCss(["basic"])` or by adding `css="basic"` to your script tag.
+
+### Key Features
+- **Box Sizing**: `border-box` globally
+- **Typography**: Default sans-serif font stack, consistent line-height
+- **Form Elements**: Inherit font styles, transparent backgrounds, `cursor: pointer` for buttons
+- **Media**: Images/videos max-width 100%
+- **Dialog**: Default backdrop styling
+- **Resets**: Removes default margins/paddings from most block elements
 
 ## Utility CSS
 
@@ -527,8 +539,6 @@ You can also control the opacity of any color utility by appending `/{opacity}` 
 | `text-{0-99}px` | Font size in pixels (e.g., `text-12px`, `text-16px`) |
 | `text-{0-24.75}rem` | Font size in rem units (0.25rem increments) |
 
----
-
 ## Custom Values
 
 When you need a value outside the design scale, use bracket notation as an escape hatch. Custom values are automatically supported when using `css="utils"` — no extra configuration needed.
@@ -592,6 +602,6 @@ Custom values support pseudo-states, responsive breakpoints, and dark mode:
 
 For content added after initial load, call `injectCss(["custom"])` again to scan and inject new on-demand values.
 
----
+--- 
 
 *Generated automatically from `src/css_gen_utils.ts`*

--- a/docs/05_css.md
+++ b/docs/05_css.md
@@ -221,6 +221,11 @@ You can also control the opacity of any color utility by appending `/{opacity}` 
 | --- | --- |
 | `transition-none` | `{"transition":"none"}` |
 | `transition` | `{"transition-property":"all","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
+| `transition-all` | `{"transition-property":"all","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
+| `transition-opacity` | `{"transition-property":"opacity","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
+| `transition-transform` | `{"transition-property":"transform","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
+| `transition-shadow` | `{"transition-property":"box-shadow","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
+| `transition-colors` | `{"transition-property":"color, background-color, border-color, text-decoration-color, fill, stroke","transition-timing-function":"ease-in-out","transition-duration":"var(--transition-duration, 150ms)"}` |
 | `animate-none` | `{"animation":"none"}` |
 | `animate-spin` | `{"animation":"spin 1s linear infinite"}` |
 | `animate-ping` | `{"animation":"ping 1s cubic-bezier(0, 0, 0.2, 1) infinite"}` |

--- a/scripts/generate-css-docs.ts
+++ b/scripts/generate-css-docs.ts
@@ -50,6 +50,12 @@ function generateMarkdown() {
 	md += "## Utility CSS\n\n";
 	md +=
 		'The utility CSS rules are inspired by Tailwind CSS. You can inject them using `injectCss(["utils"])` or by adding `css="utils"` to your script tag.\n\n';
+	md += "This automatically includes:\n";
+	md +=
+		"- **CSS Reset** (Tailwind Preflight): box-sizing, typography, form resets, media defaults\n";
+	md += "- **Base utility classes**: spacing, sizing, colors, layout, typography, and more\n";
+	md +=
+		"- **On-demand scanning**: responsive variants, pseudo-state variants, color opacity, custom bracket values, and dark mode are generated on-the-fly for only the classes actually used in your markup\n\n";
 
 	md += "### Media Breakpoints\n\n";
 	md += "| Prefix | Min Width |\n";
@@ -64,6 +70,19 @@ function generateMarkdown() {
 	md += "- `hover:`\n";
 	md += "- `focus:`\n";
 	md += "- `disabled:`\n\n";
+
+	md += "### Dark Mode\n\n";
+	md += `Use the \`dark:\` prefix to apply styles when the user's system prefers dark mode (\`prefers-color-scheme: dark\`):\n\n`;
+	md += "```html\n";
+	md += '<div class="bg-white text-gray-900 dark:bg-gray-900 dark:text-white">\n';
+	md += "  This adapts to the user's color scheme preference.\n";
+	md += "</div>\n";
+	md += "```\n\n";
+	md += `The \`dark:\` prefix can be used with any utility class, including colors, spacing, and custom bracket values:\n\n`;
+	md += "```html\n";
+	md += '<div class="bg-[#fff] dark:bg-[#1a1a1a] p-4 dark:border-gray-700">\n';
+	md += "```\n\n";
+	md += `> **Note:** Responsive variants (\`sm:\`, \`md:\`, etc.), pseudo-state variants (\`hover:\`, \`focus:\`, \`disabled:\`), color opacity (\`/N\`), dark mode (\`dark:\`), and custom bracket values are all generated on-demand. Only the classes actually present in your markup are injected, keeping the CSS bundle small.\n\n`;
 
 	md += "### Spacing (Margin & Padding)\n\n";
 	md += "Spacing utilities use a 0.25rem (4px) unit by default.\n\n";
@@ -287,6 +306,13 @@ function generateMarkdown() {
 	md += "| `col-start-{1-13}` | `grid-column-start: n` |\n";
 	md += "| `col-end-{1-13}` | `grid-column-end: n` |\n";
 	md += "| `col-start/end-auto` | `grid-column-start/end: auto` |\n";
+	md += "| `grid-rows-{1-12}` | `grid-template-rows: repeat(n, minmax(0, 1fr))` |\n";
+	md += "| `grid-rows-none` | `grid-template-rows: none` |\n";
+	md += "| `row-span-{1-12}` | `grid-row: span n / span n` |\n";
+	md += "| `row-span-full` | `grid-row: 1 / -1` |\n";
+	md += "| `row-start-{1-13}` | `grid-row-start: n` |\n";
+	md += "| `row-end-{1-13}` | `grid-row-end: n` |\n";
+	md += "| `row-start/end-auto` | `grid-row-start/end: auto` |\n";
 	md += "\n";
 
 	md += "### Position & Inset\n\n";
@@ -469,6 +495,55 @@ function generateMarkdown() {
 	md += "| `text-{0-99}px` | Font size in pixels (e.g., `text-12px`, `text-16px`) |\n";
 	md += "| `text-{0-24.75}rem` | Font size in rem units (0.25rem increments) |\n";
 	md += "\n";
+
+	md += "## Custom Values\n\n";
+	md += `When you need a value outside the design scale, use bracket notation as an escape hatch. Custom values are automatically supported when using \`css="utils"\` — no extra configuration needed.\n\n`;
+	md += "### Syntax\n\n";
+	md += "```html\n";
+	md += '<div class="w-[133px] mt-[2rem] max-w-[900px]">\n';
+	md += "```\n\n";
+	md += "### Supported Properties\n\n";
+	md += "| Prefix | CSS Property |\n";
+	md += "|--------|--------------|\n";
+	md += "| `w-` | width |\n";
+	md += "| `h-` | height |\n";
+	md += "| `min-w-`, `min-h-` | min-width, min-height |\n";
+	md += "| `max-w-`, `max-h-` | max-width, max-height |\n";
+	md += "| `m-`, `mt-`, `mr-`, `mb-`, `ml-` | margin |\n";
+	md += "| `mx-`, `my-` | margin-inline, margin-block |\n";
+	md += "| `p-`, `pt-`, `pr-`, `pb-`, `pl-` | padding |\n";
+	md += "| `px-`, `py-` | padding-inline, padding-block |\n";
+	md += "| `top`, `right`, `bottom`, `left` | positioning |\n";
+	md += "| `gap-`, `gap-x-`, `gap-y-` | gap |\n";
+	md += "| `text-` | font-size |\n";
+	md += "| `z-` | z-index |\n";
+	md += "| `bg-` | background-color |\n";
+	md += "| `border-` | border-color |\n";
+	md += "\n";
+	md += "### Variants\n\n";
+	md += "Custom values support pseudo-states, responsive breakpoints, and dark mode:\n\n";
+	md += "```html\n";
+	md += '<div class="hover:w-[200px] md:max-w-[900px] dark:bg-[#333]">\n';
+	md += "```\n\n";
+	md += "### Limitations\n\n";
+	md += "**Static classes only**: Custom values work with the `class` attribute, not `:class`:\n\n";
+	md += "```html\n";
+	md += "<!-- ✓ Works -->\n";
+	md += '<div class="w-[133px]">\n\n';
+	md += "<!-- ✗ Not supported - use inline styles instead -->\n";
+	md += `<div :class="'w-[133px]'">\n`;
+	md += `<div :attr:style="'width: ' + dynamicWidth">\n`;
+	md += "```\n\n";
+	md +=
+		"**Browser only**: Custom values require the CSSStyleSheet API and are not available in Worker or SSR environments.\n\n";
+	md += "### When to Use\n\n";
+	md += "**Prefer the design scale** for consistency. Use custom values for:\n";
+	md += "- Matching external constraints (third-party widgets, embeds)\n";
+	md += "- One-off pixel-perfect adjustments\n";
+	md += "- Rapid prototyping (replace with scale values later)\n\n";
+	md += "### Dynamic Content\n\n";
+	md +=
+		'For content added after initial load, call `injectCss(["custom"])` again to scan and inject new on-demand values.\n\n';
 
 	md += "--- \n\n*Generated automatically from `src/css_gen_utils.ts`*\n";
 

--- a/src/css_gen_utils.test.ts
+++ b/src/css_gen_utils.test.ts
@@ -126,6 +126,38 @@ describe("CSS Generation Utils", () => {
 			assert.ok(css.includes(".duration-150 {"), "Should include duration-150");
 		});
 
+		it("includes per-property transition helpers that animate standalone", () => {
+			const css = rules();
+			// Each helper must set transition-property so it animates without `transition`.
+			assert.ok(
+				css.includes(".transition-all { transition-property: all;"),
+				"Should include transition-all",
+			);
+			assert.ok(
+				css.includes(".transition-opacity { transition-property: opacity;"),
+				"Should include transition-opacity",
+			);
+			assert.ok(
+				css.includes(".transition-transform { transition-property: transform;"),
+				"Should include transition-transform",
+			);
+			assert.ok(
+				css.includes(".transition-shadow { transition-property: box-shadow;"),
+				"Should include transition-shadow",
+			);
+			assert.ok(
+				css.includes(".transition-colors { transition-property: color, background-color"),
+				"Should include transition-colors",
+			);
+			// Standalone usage requires an inherited timing-function and duration.
+			assert.ok(
+				css.includes(
+					".transition-opacity { transition-property: opacity; transition-timing-function: ease-in-out; transition-duration: var(--transition-duration, 150ms) }",
+				),
+				"transition-opacity should carry timing-function and duration",
+			);
+		});
+
 		it("includes color base classes without opacity", () => {
 			const css = rules();
 			assert.ok(css.includes(".text-white { color: #fff }"), "Should include text-white");

--- a/src/css_gen_utils.ts
+++ b/src/css_gen_utils.ts
@@ -34,6 +34,12 @@ export const PROPS_SIZING_MINMAX = {
 	"max-width": "max-w",
 	"max-height": "max-h",
 };
+// Shared timing-function and duration so every transition helper animates
+// standalone (e.g. `transition-opacity duration-300`) without needing `transition`.
+const TRANSITION_BASE = {
+	"transition-timing-function": "ease-in-out",
+	"transition-duration": "var(--transition-duration, 150ms)",
+};
 export const PROPS_CUSTOM = {
 	// Based on https://tailwindcss.com.
 	// Font family.
@@ -300,10 +306,16 @@ export const PROPS_CUSTOM = {
 	"backdrop-blur-3xl": { "backdrop-filter": "blur(64px)" },
 	// Transitions.
 	"transition-none": { transition: "none" },
-	transition: {
-		"transition-property": "all",
-		"transition-timing-function": "ease-in-out",
-		"transition-duration": "var(--transition-duration, 150ms)",
+	transition: { "transition-property": "all", ...TRANSITION_BASE },
+	// Per-property helpers mirroring Tailwind's transition-property utilities.
+	"transition-all": { "transition-property": "all", ...TRANSITION_BASE },
+	"transition-opacity": { "transition-property": "opacity", ...TRANSITION_BASE },
+	"transition-transform": { "transition-property": "transform", ...TRANSITION_BASE },
+	"transition-shadow": { "transition-property": "box-shadow", ...TRANSITION_BASE },
+	"transition-colors": {
+		"transition-property":
+			"color, background-color, border-color, text-decoration-color, fill, stroke",
+		...TRANSITION_BASE,
 	},
 	// Animations.
 	"animate-none": { animation: "none" },


### PR DESCRIPTION
## Summary

Adds the per-property transition utilities that mirror Tailwind's [transition-property API](https://tailwindcss.com/docs/transition-property), which were missing from `css_gen_utils`:

| Utility | `transition-property` |
| --- | --- |
| `transition-all` | `all` |
| `transition-opacity` | `opacity` |
| `transition-transform` | `transform` |
| `transition-shadow` | `box-shadow` |
| `transition-colors` | `color, background-color, border-color, text-decoration-color, fill, stroke` |

## Why

Before this change only `transition` (`transition-property: all`) and `transition-none` existed. Classes like `transition-opacity duration-300` were *accepted* by the matcher but emitted no `transition-property`, so the duration was set with nothing to animate — a silent dead transition. The property-scoped variants also keep `opacity`/`transform` animations on the compositor instead of invalidating layout via `all`.

```html
<!-- before: snaps (transition-property unset); after: fades for 1s -->
<div class="opacity-0 transition-opacity duration-1000"></div>
```

## Implementation

Each helper inherits a shared `ease-in-out` timing function and `var(--transition-duration, 150ms)` (extracted into a `TRANSITION_BASE` const, also reused by the existing `transition`) so the variants animate standalone when paired with a `duration-*` helper.

## Notes

- The existing `transition` is left mapping to `transition-property: all` (unchanged) to avoid a behavior change for current consumers; aligning it to Tailwind's explicit list (the side note in the issue) is left as separate follow-up.
- Docs table (`docs/05_css.md`) updated to match.

## Testing

- Added a unit test asserting each helper emits its `transition-property` plus the timing-function and duration.
- `npm run test:node` — 1132 passing.
- `biome check` — clean.

Closes #63